### PR TITLE
fix CRSF cookie for chrome

### DIFF
--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -2,6 +2,8 @@ import { doubleCsrf } from "csrf-csrf";
 
 export const csrf = doubleCsrf({
   getSecret: _req => "my-other-super-secret-key",
+  // __Host-psifi.x-csrf-token does not work with localhost
+  cookieName: "x-csrf-token",
   cookieOptions: {
     httpOnly: true,
     // sameSite: "strict",


### PR DESCRIPTION
CRSF is broken when running on chrome:

<img width="519" alt="image" src="https://github.com/jasonraimondi/ts-oauth2-server-example/assets/429676/2a41b8b3-47ae-4315-af9c-fe302c49567c">

__Host cookie only work when using https

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes