### PR TITLE
separate backend and frontend

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,8 +35,9 @@ async function bootstrap() {
   );
   app.setGlobalPrefix("api");
 
+  app.enableCors();
   await app.listen(3000);
-
+  console.log(`Backend running: http://localhost:3000/`);
   console.log(`Sample Login: http://localhost:5173/`);
 }
 

--- a/web/src/lib/http_client.ts
+++ b/web/src/lib/http_client.ts
@@ -1,3 +1,3 @@
 import wretch from "wretch";
 
-export const httpClient = wretch("http://localhost:5173");
+export const httpClient = wretch("http://localhost:3000");

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -3,7 +3,7 @@
   import { CALLBACK_URL, CLIENT_ID, createAuth } from "$lib/auth";
   import { SESSION_STORAGE } from "$lib/browser_storage";
 
-  const url = new URL("http://localhost:5173/api/oauth2/authorize");
+  const url = new URL("http://localhost:3000/api/oauth2/authorize");
 
   onMount(async () => {
     const { state, verifier, challenge } = await createAuth();


### PR DESCRIPTION
when first looking at the example I was a bit confused that both the client spa and server where accessed via localhost:5137

Separating them on different ports makes it more clear that the spa and the backend are completely independent